### PR TITLE
[Update by Gordon Tsai at Aug 17]

### DIFF
--- a/material/handlers/material_helper.js
+++ b/material/handlers/material_helper.js
@@ -1,0 +1,101 @@
+/*
+	Author: Shang-Yi Tsai 
+	Module : To get academic data according to passed user data
+	About : Together with usersample.json 
+	Date : 2014/08/14
+	[Done]
+	1.
+	[Unfinished]
+	1.Waiting for rewrote into module form..
+	2.
+*/
+var async = require('async');
+var fs = require('fs');
+//method : Get info of user's subject name according to the identity info.
+//detail : pass the user's accessible subject's permanent ID to this function,and get material_contents!
+exports.getSubjectList=function(material_name, page, page_size, callback)
+{
+	//use waterfall to implement it
+	async.waterfall([
+		//Step1. Read the user info from usersample.json	
+		function(callback){	
+			//err & contents is passed to next function
+			console.log("No1");
+			//It looks weird cause I didn't see any err passed to next function.[Discussion]
+			//Maybe the err was passed to callback directly.
+			fs.readFile("./users/user.json",callback);
+		},
+		//Step2. Get contents
+		function(contents,callback){
+			console.log("No2b");
+			contents=JSON.parse(contents);
+			//Find out accessible material direct
+			access_material=contents.Academic.TakenSubject[material_name.toString('utf8')][0];
+			//
+			var path = "materials/" + material_name + "/"+access_material;	
+			callback(null,path);
+		},
+		//use parameter path to read direct
+		function(path,callback){
+			fs.readdir(
+				path,
+			function(err,files) {
+			console.log("No4");
+			console.log(path);
+			console.log(files.toString('utf8'));
+			console.log("No4b");
+			var only_files=[];
+			async.forEach(
+				files,
+				function (element, cb) {
+					//console.log(path + element);
+					fs.stat(
+						path +"/"+element,
+						function (err, stats) {
+							if (err) {
+								cb(helpers.make_error("file_error",JSON.stringify(err)));
+								return;
+							}
+							if (stats.isFile()) {
+								//console.log("*");
+								//console.log(stats.toString('utf8'));
+								var obj = { filename: element,desc: element };
+								only_files.push(obj);
+							}
+									cb(null);
+								}                    
+					);
+				},
+				function (err) {
+					if (err) {callback(err);} 
+					else {
+						var ps = page_size;
+						var mfiles = only_files.splice(page * ps, ps);
+						var obj = { short_name: material_name,mfiles: mfiles };
+						callback(null, obj);
+					}
+				}
+			);
+		});}],
+		function(err, material_contents){
+			console.log("No5");
+			console.log(err);
+			console.log(material_contents);
+			if (err) {
+						console.log("No4a");
+						if (err.code == "ENOENT") {
+							callback(helpers.no_such_material(),null);
+						} 
+						else {
+							callback(helpers.make_error("file_error",JSON.stringify(err)));
+						}
+						return;
+					}
+			//callback(err, material_contents);
+		}
+	);
+}
+function load_UserData(){
+}
+function show_TakenSemester(){
+}

--- a/material/handlers/materials.js
+++ b/material/handlers/materials.js
@@ -1,7 +1,8 @@
 var helpers = require('./helpers.js'),
     async = require('async'),
-    fs = require('fs');
-
+    fs = require('fs'),
+	mhelper=require('./material_helper');
+	
 exports.version = "0.1.0";
 
 exports.list_all = function (req, res) {
@@ -77,6 +78,14 @@ function load_material_list(callback) {
         }
     );
 };
+function load_material(material_name, page, page_size, callback){
+	mhelper.getSubjectList(material_name, page, page_size, callback);
+
+}
+
+
+
+/*
 function load_material(material_name, page, page_size, callback) {
 	//console.log("load_material");
 	var access_material;
@@ -148,7 +157,7 @@ function load_material(material_name, page, page_size, callback) {
 		}
     );
 	
-};
+};*/
 //get_access_material:
 //It return the folder depends on the user json-file in /users,thought I wonder it's necessity... 
 //[improve]It should not be implemented like this.

--- a/material/users/user.json
+++ b/material/users/user.json
@@ -1,6 +1,29 @@
 {
-	"ID":"011079",
-	"Name":"Gordon",
-	"UEE1303":"1060",
-	"UEE2303":"1072"
+	"Identity":{
+		"ID":"0110789",
+		"Name":"蔡尚頤",
+		"SemesterHistory":[
+			"101a","101b"
+		]
+	},
+	"Academic":{
+		"TakenSemester":{
+			"101a":{
+				"Subject":[
+					"UEE1303",
+					"UEE2303"
+				]
+			},
+			"101b":{
+				"Subject":[
+					"UEE1303",
+					"UEE2303"
+				]
+			}	
+		},
+		"TakenSubject":{
+			"UEE1303":["1060","1061"],
+			"UEE2303":["1072","1073"]
+		}
+	}
 }


### PR DESCRIPTION
---

[Newly Done]
1. [Done-4]
2. [Done-6]
3. [Done-7]

[Done]
1. (tempalately)Use user.json to specified user identity.
2. Server open the material folder depends on user.For example, AOOP's permanent ID is UEE1303，and I took this class in 102B(current ID:1060)，so when I
   view the AOOP material，what I see would be UEE1303/1060.
3. Be able to get file names in dir,but failed to load it to the page. View [Wait for improved-1].
4. Improved user.json format.
5. Fixed:Failed to get JSON file property .(\handlers\materials.js :Line 92)
6. Fixed:function load_material should be rewrite with async.waterfall or something else,rather than nested structure.(\handlers\materials.js :Line80-148)
7. Fixed:Failed to read files from dir.

[Wait for improved]
1.Failed to load file to the page,but it absolutely has got files' name.

[Wait for discussion]
1. Improve the format of user json.
2. (\handlers\material_helper.js Line24)
