### PR TITLE
[Update by Gordon Tsai at Aug 26]

### DIFF
--- a/material/basic.html
+++ b/material/basic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Lecture material</title>
+  <title>{{PAGE_NAME}}</title>
  
   <!-- Meta -->
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />

--- a/material/content/material.js
+++ b/material/content/material.js
@@ -7,6 +7,7 @@ $(function(){
 		// get material name.
         parts = window.location.href.split("/");
         var material_name = parts[5];
+		console.log(parts);
 		// Load the HTML template
         $.get("/templates/material.html", function(d){
             tmpl = d;
@@ -29,7 +30,7 @@ function massage_material(d) {
     if (d.error != null) return d;
     var obj = { mfiles: [] };
 
-    var af = d.data.material_data;
+    var af = d.data.material_contents_data;
 
     for (var i = 0; i < af.mfiles.length; i++) {
         var url = "/materials/" + af.short_name + "/" + af.mfiles[i].filename;

--- a/material/handlers/helpers.js
+++ b/material/handlers/helpers.js
@@ -10,9 +10,16 @@ exports.make_error = function(err, msg) {
 
 
 exports.send_success = function(res, data) {
+	console.log("send_success");
     res.writeHead(200, {"Content-Type": "application/json"});
     var output = { error: null, data: data };
+	console.log(output);
     res.end(JSON.stringify(output) + "\n");
+	/*
+	console.log("*");
+	console.log(res);
+	console.log("**");
+	*/
 }
 
 

--- a/material/handlers/material_helper.js
+++ b/material/handlers/material_helper.js
@@ -16,18 +16,17 @@ var fs = require('fs');
 exports.getSubjectList=function(material_name, page, page_size, callback)
 {
 	//use waterfall to implement it
+	
 	async.waterfall([
 		//Step1. Read the user info from usersample.json	
 		function(callback){	
 			//err & contents is passed to next function
-			console.log("No1");
 			//It looks weird cause I didn't see any err passed to next function.[Discussion]
 			//Maybe the err was passed to callback directly.
 			fs.readFile("./users/user.json",callback);
 		},
 		//Step2. Get contents
 		function(contents,callback){
-			console.log("No2b");
 			contents=JSON.parse(contents);
 			//Find out accessible material direct
 			access_material=contents.Academic.TakenSubject[material_name.toString('utf8')][0];
@@ -40,15 +39,10 @@ exports.getSubjectList=function(material_name, page, page_size, callback)
 			fs.readdir(
 				path,
 			function(err,files) {
-			console.log("No4");
-			console.log(path);
-			console.log(files.toString('utf8'));
-			console.log("No4b");
 			var only_files=[];
 			async.forEach(
 				files,
 				function (element, cb) {
-					//console.log(path + element);
 					fs.stat(
 						path +"/"+element,
 						function (err, stats) {
@@ -57,8 +51,6 @@ exports.getSubjectList=function(material_name, page, page_size, callback)
 								return;
 							}
 							if (stats.isFile()) {
-								//console.log("*");
-								//console.log(stats.toString('utf8'));
 								var obj = { filename: element,desc: element };
 								only_files.push(obj);
 							}
@@ -71,18 +63,15 @@ exports.getSubjectList=function(material_name, page, page_size, callback)
 					else {
 						var ps = page_size;
 						var mfiles = only_files.splice(page * ps, ps);
-						var obj = { short_name: material_name,mfiles: mfiles };
+						//console.log(material_name + "/"+access_material);
+						var obj = { short_name:material_name + "/"+access_material,mfiles: mfiles };
 						callback(null, obj);
 					}
 				}
 			);
 		});}],
 		function(err, material_contents){
-			console.log("No5");
-			console.log(err);
-			console.log(material_contents);
 			if (err) {
-						console.log("No4a");
 						if (err.code == "ENOENT") {
 							callback(helpers.no_such_material(),null);
 						} 
@@ -91,7 +80,7 @@ exports.getSubjectList=function(material_name, page, page_size, callback)
 						}
 						return;
 					}
-			//callback(err, material_contents);
+			callback(err, material_contents);
 		}
 	);
 }

--- a/material/handlers/materials.js
+++ b/material/handlers/materials.js
@@ -15,8 +15,10 @@ exports.list_all = function (req, res) {
     });
 };
 exports.material_by_name = function (req, res) {
-	console.log("material_by_name");
     // get the GET params
+	//
+	console.log("material_by_name");
+	//
     var getp = req.query;
     var page_num = getp.page ? getp.page : 0;
     var page_size = getp.page_size ? getp.page_size : 1000;
@@ -32,11 +34,15 @@ exports.material_by_name = function (req, res) {
         page_size,
         function (err, material_contents) {
             if (err && err.error == "no_such_material") {
+				console.log("no~~");
                 helpers.send_failure(res, 404, err);
             }  else if (err) {
+				console.log("oh!");
                 helpers.send_failure(res, 500, err);
             } else {
-                helpers.send_success(res, { material_contents_data: material_contents });
+				console.log("Ya!");
+				console.log({ material_contents_data: material_contents });
+				helpers.send_success(res, { material_contents_data: material_contents });
             }
         }
     );
@@ -82,96 +88,3 @@ function load_material(material_name, page, page_size, callback){
 	mhelper.getSubjectList(material_name, page, page_size, callback);
 
 }
-
-
-
-/*
-function load_material(material_name, page, page_size, callback) {
-	//console.log("load_material");
-	var access_material;
-	fs.readFile(
-		"./users/user.json",
-		function(err,contents){
-			if(err){console.log(err);return;}
-			var tmp=material_name.toString('utf8');
-			contents=JSON.parse(contents);
-			access_material=contents[tmp];
-			//console.log(tmp);
-			var only_files = [];
-			
-			var path = "materials/" + material_name + "/"+access_material;	
-			
-			//console.log(path);
-			fs.readdir(
-				path,
-				function (err, files) {
-					if (err) {
-						if (err.code == "ENOENT") {
-							callback(helpers.no_such_material());
-						} 
-						else {
-							callback(helpers.make_error("file_error",JSON.stringify(err)));
-						}
-						return;
-					}
-					//console.log("OK");
-					async.forEach(
-						files,
-						function (element, cb) {
-							console.log(path + element);
-							fs.stat(
-								path +"/"+element,
-								function (err, stats) {
-									//console.log(stats.isFile());
-									if (err) {
-										cb(helpers.make_error("file_error",JSON.stringify(err)));
-										return;
-									}
-									if (stats.isFile()) {
-									//console.log("*");
-										var obj = { filename: element,desc: element };
-										only_files.push(obj);
-									}
-									cb(null);
-								}                    
-							);
-						},
-						function (err) {
-							if (err) {
-								callback(err);
-							} 
-							else {
-								var ps = page_size;
-								var mfiles = only_files.splice(page * ps, ps);
-								var obj = { short_name: material_name,mfiles: mfiles };
-								callback(null, obj);
-							}
-						}
-					);
-				}
-			
-			);
-            
-
-            
-		}
-    );
-	
-};*/
-//get_access_material:
-//It return the folder depends on the user json-file in /users,thought I wonder it's necessity... 
-//[improve]It should not be implemented like this.
-/*function get_access_material(material_name){
-	fs.readFile(
-		"/users/user.json",
-		function(err,contents){
-			if(err){
-				return {material_name:"not_access"};
-			}
-			return contents.material_name.toString('utf8');}
-	);
-}
-
-console.log("access_material: "+access_material);
-
-*/

--- a/material/handlers/pages.js
+++ b/material/handlers/pages.js
@@ -7,13 +7,14 @@ exports.version = "0.1.0";
 
 
 exports.generate = function (req, res) {
-
+	console.log("generate");
     var page = req.params.page_name;
-
+	console.log(page);
     fs.readFile(
         'basic.html',
         function (err, contents) {
             if (err) {
+				console.log("ohoh!");
                 send_failure(res, 500, err);
                 return;
             }
@@ -21,6 +22,8 @@ exports.generate = function (req, res) {
             contents = contents.toString('utf8');
 
             // replace page name, and then dump to output.
+			//[Discussion]26,27
+            contents = contents.replace('{{PAGE_NAME}}', page);
             contents = contents.replace('{{PAGE_NAME}}', page);
             res.writeHead(200, { "Content-Type": "text/html" });
             res.end(contents);

--- a/material/server.js
+++ b/material/server.js
@@ -10,8 +10,20 @@ var fs = require('fs'),
 
 app.get('/v1/materials.json', material_hdlr.list_all);
 app.get('/v1/materials/:material_name.json', material_hdlr.material_by_name);
-app.get('/pages/:page_name', page_hdlr.generate);
-app.get('/pages/:page_name/:sub_page', page_hdlr.generate);
+app.get('/pages/:page_name',function (req, res) {
+	console.log('/pages/:page_name');
+	console.log(req.params.page_name);
+	page_hdlr.generate(req, res);
+	});
+app.get('/pages/:page_name/:sub_page',function (req, res) {
+	console.log('/pages/:page_name/:sub_page');
+	console.log(req.params.page_name);
+	console.log(req.params.sub_page);
+	page_hdlr.generate(req, res);
+	});
+//[CAUTION] I think the following way is quite careless,
+//			but please pardon me for implementing it in this way temperately.
+app.get('/pages/:page_name/:sub_page/:sub_page', page_hdlr.generate);
 app.get('/content/:filename', function (req, res) {
     serve_static_file('content/' + req.params.filename, res);
 });
@@ -26,6 +38,7 @@ app.get('*', four_oh_four);
 
 
 function four_oh_four(req, res) {
+	console.log("404");
     res.writeHead(404, { "Content-Type" : "application/json" });
     res.end(JSON.stringify(helpers.invalid_resource()) + "\n");
 }

--- a/material/templates/home.html
+++ b/material/templates/home.html
@@ -1,5 +1,5 @@
 <div id="album_list">
-  <p> There are {{ materials.length }} materials</p>
+  <p> There are {{ materials.length }} lecture</p>
   <ul id="materials">
     {{#materials}}
       <li class="material">


### PR DESCRIPTION
---

[Newly Done]
1. [Done-8]

[Done]
1. (tempalately)Use user.json to specified user identity.
2. Server open the material folder depends on user.For example, AOOP's permanent ID is UEE1303，and I took this class in 102B(current ID:1060)，so when I
   view the AOOP material，what I see would be UEE1303/1060.
3. Be able to get file names in dir,but failed to load it to the page.
4. Improved user.json format.
5. Fixed:Failed to get JSON file property .(\handlers\materials.js :Line 92)
6. Fixed:function load_material should be rewrite with async.waterfall or something else,rather than nested structure.(\handlers\materials.js :Line80-148)
7. Fixed:Failed to read files from dir.
8. Fixed:Failed to load file to the page,but it absolutely has got files' name.(\material\content\material.js :Line33)

[Wait for improved]
1.Clean up all of the test code such as "console.log",etc.
2.Disign the page of showing up material files.(It is currently the form of the example in the textbook.)
3.Some useful functions in load_material (\handlers\materials.js) should be separated ,and rewrited into named functions.

[Wait for discussion]
1. Improve the format of user json.
2. (\handlers\material_helper.js Line24)
