### PR TITLE
[Update by Gordon Tsai at Aug 26 ver.2]

### DIFF
--- a/material/content/material.js
+++ b/material/content/material.js
@@ -26,14 +26,13 @@ $(function(){
     }();
 });
 function massage_material(d) {
-	console.log("massage_material");
     if (d.error != null) return d;
     var obj = { mfiles: [] };
 
     var af = d.data.material_contents_data;
 
     for (var i = 0; i < af.mfiles.length; i++) {
-        var url = "/materials/" + af.short_name + "/" + af.mfiles[i].filename;
+        var url = af.short_name +"/"+ af.mfiles[i].filename;
         obj.mfiles.push({ url: url, desc: af.mfiles[i].filename });
     }
     return obj;

--- a/material/handlers/helpers.js
+++ b/material/handlers/helpers.js
@@ -10,16 +10,9 @@ exports.make_error = function(err, msg) {
 
 
 exports.send_success = function(res, data) {
-	console.log("send_success");
     res.writeHead(200, {"Content-Type": "application/json"});
     var output = { error: null, data: data };
-	console.log(output);
     res.end(JSON.stringify(output) + "\n");
-	/*
-	console.log("*");
-	console.log(res);
-	console.log("**");
-	*/
 }
 
 

--- a/material/handlers/material_helper.js
+++ b/material/handlers/material_helper.js
@@ -31,7 +31,7 @@ exports.getSubjectList=function(material_name, page, page_size, callback)
 			//Find out accessible material direct
 			access_material=contents.Academic.TakenSubject[material_name.toString('utf8')][0];
 			//
-			var path = "materials/" + material_name + "/"+access_material;	
+			var path = "materials/" + material_name + "/"+access_material;
 			callback(null,path);
 		},
 		//use parameter path to read direct
@@ -52,6 +52,9 @@ exports.getSubjectList=function(material_name, page, page_size, callback)
 							}
 							if (stats.isFile()) {
 								var obj = { filename: element,desc: element };
+								//
+								console.log(obj.filename);
+								//
 								only_files.push(obj);
 							}
 									cb(null);
@@ -64,7 +67,8 @@ exports.getSubjectList=function(material_name, page, page_size, callback)
 						var ps = page_size;
 						var mfiles = only_files.splice(page * ps, ps);
 						//console.log(material_name + "/"+access_material);
-						var obj = { short_name:material_name + "/"+access_material,mfiles: mfiles };
+						var obj = { short_name:material_name+"/"+access_material,mfiles: mfiles };
+						console.log(obj.short_name);
 						callback(null, obj);
 					}
 				}

--- a/material/handlers/materials.js
+++ b/material/handlers/materials.js
@@ -16,9 +16,6 @@ exports.list_all = function (req, res) {
 };
 exports.material_by_name = function (req, res) {
     // get the GET params
-	//
-	console.log("material_by_name");
-	//
     var getp = req.query;
     var page_num = getp.page ? getp.page : 0;
     var page_size = getp.page_size ? getp.page_size : 1000;
@@ -34,14 +31,10 @@ exports.material_by_name = function (req, res) {
         page_size,
         function (err, material_contents) {
             if (err && err.error == "no_such_material") {
-				console.log("no~~");
                 helpers.send_failure(res, 404, err);
             }  else if (err) {
-				console.log("oh!");
                 helpers.send_failure(res, 500, err);
             } else {
-				console.log("Ya!");
-				console.log({ material_contents_data: material_contents });
 				helpers.send_success(res, { material_contents_data: material_contents });
             }
         }

--- a/material/handlers/pages.js
+++ b/material/handlers/pages.js
@@ -7,14 +7,11 @@ exports.version = "0.1.0";
 
 
 exports.generate = function (req, res) {
-	console.log("generate");
     var page = req.params.page_name;
-	console.log(page);
     fs.readFile(
         'basic.html',
         function (err, contents) {
             if (err) {
-				console.log("ohoh!");
                 send_failure(res, 500, err);
                 return;
             }

--- a/material/server.js
+++ b/material/server.js
@@ -11,14 +11,9 @@ var fs = require('fs'),
 app.get('/v1/materials.json', material_hdlr.list_all);
 app.get('/v1/materials/:material_name.json', material_hdlr.material_by_name);
 app.get('/pages/:page_name',function (req, res) {
-	console.log('/pages/:page_name');
-	console.log(req.params.page_name);
 	page_hdlr.generate(req, res);
 	});
 app.get('/pages/:page_name/:sub_page',function (req, res) {
-	console.log('/pages/:page_name/:sub_page');
-	console.log(req.params.page_name);
-	console.log(req.params.sub_page);
 	page_hdlr.generate(req, res);
 	});
 //[CAUTION] I think the following way is quite careless,
@@ -27,9 +22,10 @@ app.get('/pages/:page_name/:sub_page/:sub_page', page_hdlr.generate);
 app.get('/content/:filename', function (req, res) {
     serve_static_file('content/' + req.params.filename, res);
 });
-app.get('/materials/:material_name/:filename', function (req, res) {
-    serve_static_file('materials/' + req.params.material_name + "/"
-                      + req.params.filename, res);
+app.get('/materials/:permanent_ID/:current_ID/:filename', function (req, res) {
+	var url='materials/'+req.params.permanent_ID+"/"+req.params.current_ID+"/"+req.params.filename;
+	console.log(url);
+    serve_static_file(url, res);
 });
 app.get('/templates/:template_name', function (req, res) {
     serve_static_file("templates/" + req.params.template_name, res);

--- a/material/templates/material.html
+++ b/material/templates/material.html
@@ -1,17 +1,15 @@
-<div id="album_page">
+<div id="file_page">
   {{#mfiles}}
-  <p> There are {{ mfiles.length }} mfiles in this album</p>
+  <p> There are {{ mfiles.length }} files in this subject</p>
   <div id="mfiles">
       <div class="mfile">
         <div class='mfile_holder'>
-          <img style='width: 250px; height: 250px; background-color: #fbb'
-               src="{{url}}" border="0"/></div>
-        <div class='mfile_desc'><p>{{ desc }}</p></div>
+        <a href='http://localhost:8080/materials/{{url}}'>{{ desc }}</a></div >
       </div>
   </div> <!-- #mfiles -->
   <div style="clear: left"></div>
   {{/mfiles}}
   {{^mfiles}}
-      <p> This album does't have any mfiles in it, sorry.<p>
+      <p> This album does't have any files in it, sorry.<p>
   {{/mfiles}}
-</div> <!-- #album_page -->
+</div> <!-- #file_page -->


### PR DESCRIPTION
---

[Newly Done]
1. [Done-9]

[Done]
1. (tempalately)Use user.json to specified user identity.
2. Server open the material folder depends on user.For example, AOOP's permanent ID is UEE1303，and I took this class in 102B(current ID:1060)，so when I
   view the AOOP material，what I see would be UEE1303/1060.
3. Be able to get file names in dir,but failed to load it to the page.
4. Improved user.json format.
5. Fixed:Failed to get JSON file property .(\handlers\materials.js :Line 92)
6. Fixed:function load_material should be rewrite with async.waterfall or something else,rather than nested structure.(\handlers\materials.js :Line80-148)
7. Fixed:Failed to read files from dir.
8. Fixed:Failed to load file to the page,but it absolutely has got files' name.(\material\content\material.js :Line33)
9. Fixed:Disign the page of showing up material files.(It is currently the form of the example in the textbook.)

[Wait for improved]
1.Clean up all of the test code such as "console.log",etc.
2.Some useful functions in load_material (\handlers\materials.js) should be separated ,and rewrited into named functions.
3.The browser failed to get material file from server.

[Wait for discussion]
1. Improve the format of user json.
2. (\handlers\material_helper.js Line24)
