### PR TITLE
[Update by Gordon Tsai at Aug 27]

### DIFF
--- a/material/content/material.js
+++ b/material/content/material.js
@@ -7,7 +7,6 @@ $(function(){
 		// get material name.
         parts = window.location.href.split("/");
         var material_name = parts[5];
-		console.log(parts);
 		// Load the HTML template
         $.get("/templates/material.html", function(d){
             tmpl = d;

--- a/material/server.js
+++ b/material/server.js
@@ -16,9 +16,6 @@ app.get('/pages/:page_name',function (req, res) {
 app.get('/pages/:page_name/:sub_page',function (req, res) {
 	page_hdlr.generate(req, res);
 	});
-//[CAUTION] I think the following way is quite careless,
-//			but please pardon me for implementing it in this way temperately.
-app.get('/pages/:page_name/:sub_page/:sub_page', page_hdlr.generate);
 app.get('/content/:filename', function (req, res) {
     serve_static_file('content/' + req.params.filename, res);
 });
@@ -56,7 +53,6 @@ function serve_static_file(file, res) {
                 res.end();
             }
         );
-
         var ct = content_type_for_file(file);
         res.writeHead(200, { "Content-Type" : ct });
         rs.pipe(res);
@@ -69,6 +65,7 @@ function content_type_for_file (file) {
         case ".js": return "text/javascript";
         case ".css": return 'text/css';
         case '.jpg': case '.jpeg': return 'image/jpeg';
+		case ".pdf": return "application/pdf";
         default: return 'text/plain';
     }
 }

--- a/material/templates/material.html
+++ b/material/templates/material.html
@@ -1,6 +1,6 @@
 <div id="file_page">
-  {{#mfiles}}
   <p> There are {{ mfiles.length }} files in this subject</p>
+  {{#mfiles}}
   <div id="mfiles">
       <div class="mfile">
         <div class='mfile_holder'>


### PR DESCRIPTION
---

[Newly Done]
1. [Done-10]

[Done]
1. (tempalately)Use user.json to specified user identity.
2. Server open the material folder depends on user.For example, AOOP's permanent ID is UEE1303，and I took this class in 102B(current ID:1060)，so when I
   view the AOOP material，what I see would be UEE1303/1060.
3. Be able to get file names in dir,but failed to load it to the page.
4. Improved user.json format.
5. Fixed:Failed to get JSON file property .(\handlers\materials.js :Line 92)
6. Fixed:function load_material should be rewrite with async.waterfall or something else,rather than nested structure.(\handlers\materials.js :Line80-148)
7. Fixed:Failed to read files from dir.
8. Fixed:Failed to load file to the page,but it absolutely has got files' name.(\material\content\material.js :Line33)
9. Fixed:Disign the page of showing up material files.(It is currently the form of the example in the textbook.)
10.Fixed:The browser failed to get material file from server.

[Wait for improved]
1.Clean up all of the test code such as "console.log",etc.
2.Some useful functions in load_material (\handlers\materials.js) should be separated ,and rewrited into named functions.

[Wait for discussion]
1. Improve the format of user json.
2. (\handlers\material_helper.js Line24)
